### PR TITLE
[DevOps] Fix render.com build issues

### DIFF
--- a/apps/email-service/Dockerfile
+++ b/apps/email-service/Dockerfile
@@ -8,4 +8,6 @@ FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/build/libs/email-service-0.0.1-SNAPSHOT.jar app.jar
 COPY .env . 
-ENTRYPOINT ["sh", "-c", "while IFS='=' read -r k v; do export "$k=$v"; done < .env && java -jar app.jar"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/apps/email-service/entrypoint.sh
+++ b/apps/email-service/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+while IFS='=' read -r k v; do
+  export "$k=$v"
+done < .env
+
+exec java -jar app.jar


### PR DESCRIPTION
Docker has some goofy issues related to exporting variables directly from .env file.
Both build & run commands treat different combos of quotes, double quotes, spaces etc. differently.

Bash also has some quirks when exporting .env variables via different combinations of `cat` + `export` or eval. 

This caused a complete remake of the Dockerfile.
Beside that an entrypoint.sh script was added for easier modification of runtime start commands.

The script exports the variables from a .env file to a local environment, for now it works flawlessly both via docker build, docker run & also on my local machine
