### PR TITLE
build: use tsup instead of tsc as a bundler

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npx tsc",
+    "build": "npx tsup",
     "start": "node dist/index.js",
     "start:debug": "npx nodemon dist",
     "dev": "npx tsup --watch --onSuccess \"npx nodemon dist/index.mjs\""


### PR DESCRIPTION
tsc throws errors related to path aliases and reference of outside
packages
